### PR TITLE
fix(audio): eliminate gapless transition gaps on Android

### DIFF
--- a/patches/expo-audio.patch
+++ b/patches/expo-audio.patch
@@ -61,7 +61,7 @@ index 72a6e9e990bdc9bab549536981fc2e08eeb4837e..2e60864d82e7e733ceb1cf15b73aaaca
          runOnMain {
            ref.setActiveForLockScreen(active, metadata, options)
 diff --git a/android/src/main/java/expo/modules/audio/AudioPlayer.kt b/android/src/main/java/expo/modules/audio/AudioPlayer.kt
-index f7c43641fc12b627c70759fb49bbe65e746c4c1d..f01071628a1e316782818592d7b44b9c799b1ddc 100644
+index f7c43641fc12b627c70759fb49bbe65e746c4c1d..3919105 100644
 --- a/android/src/main/java/expo/modules/audio/AudioPlayer.kt
 +++ b/android/src/main/java/expo/modules/audio/AudioPlayer.kt
 @@ -7,6 +7,7 @@ import android.media.audiofx.Visualizer
@@ -82,8 +82,15 @@ index f7c43641fc12b627c70759fb49bbe65e746c4c1d..f01071628a1e316782818592d7b44b9c
  private const val SEEK_JUMP_INTERVAL_MS: Long = 10_000
  
  @UnstableApi
-@@ -50,6 +54,19 @@ class AudioPlayer(
-   ExoPlayer.Builder(context)
+@@ -47,9 +51,25 @@ class AudioPlayer(
+   private val updateInterval: Double,
+   bufferDurationMs: Long = 0
+ ) : SharedRef<ExoPlayer>(
+-  ExoPlayer.Builder(context)
++  ExoPlayer.Builder(
++    context,
++    BitPerfectRenderersFactory(context)
++  )
      .setLooper(context.mainLooper)
      .setAudioAttributes(AudioAttributes.DEFAULT, false)
 +    // Pause when the audio output becomes noisy (wired headphones unplugged or a
@@ -102,7 +109,7 @@ index f7c43641fc12b627c70759fb49bbe65e746c4c1d..f01071628a1e316782818592d7b44b9c
      .setSeekForwardIncrementMs(SEEK_JUMP_INTERVAL_MS)
      .setSeekBackIncrementMs(SEEK_JUMP_INTERVAL_MS)
      .apply {
-@@ -114,6 +131,42 @@ class AudioPlayer(
+@@ -114,6 +134,42 @@ class AudioPlayer(
      startUpdating()
    }
  
@@ -145,7 +152,7 @@ index f7c43641fc12b627c70759fb49bbe65e746c4c1d..f01071628a1e316782818592d7b44b9c
    fun setActiveForLockScreen(active: Boolean, metadata: Metadata? = null, options: AudioLockScreenOptions? = null) {
      if (active) {
        this.metadata = metadata
-@@ -222,6 +275,13 @@ class AudioPlayer(
+@@ -222,6 +278,13 @@ class AudioPlayer(
        }
  
        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
@@ -471,3 +478,285 @@ index 93b69010ae4cef81c18761ca4fedca8b4089f16f..334fe5561b4ed16e1b093d9764aa94f4
  };
  export declare class AudioRecorder extends SharedObject<RecordingEvents> {
      /**
+diff --git a/android/src/main/java/expo/modules/audio/BitPerfectRenderersFactory.java b/android/src/main/java/expo/modules/audio/BitPerfectRenderersFactory.java
+new file mode 100644
+index 0000000..7c17be1
+--- /dev/null
++++ b/android/src/main/java/expo/modules/audio/BitPerfectRenderersFactory.java
+@@ -0,0 +1,276 @@
++package expo.modules.audio;
++
++import android.content.Context;
++import android.media.AudioManager;
++import android.media.AudioTrack;
++import androidx.annotation.Nullable;
++import androidx.media3.common.C;
++import androidx.media3.common.Format;
++import androidx.media3.common.MimeTypes;
++import androidx.media3.common.util.UnstableApi;
++import androidx.media3.common.util.Util;
++import androidx.media3.exoplayer.DefaultRenderersFactory;
++import androidx.media3.exoplayer.audio.AudioSink;
++import androidx.media3.exoplayer.audio.DefaultAudioSink;
++import androidx.media3.exoplayer.audio.DefaultAudioTrackProvider;
++import androidx.media3.exoplayer.audio.ForwardingAudioSink;
++import java.nio.ByteBuffer;
++
++/**
++ * Media3 output path for unaltered Original-quality PCM.
++ *
++ * <p>Two Media3 defaults need changing for this:
++ *
++ * <ul>
++ *   <li>Compressed decoders otherwise emit 16-bit PCM, truncating 24-bit files.
++ *   <li>Every new PCM AudioTrack gets a 20 ms software volume ramp that changes source samples.
++ * </ul>
++ *
++ * <p>Float output represents every 24-bit integer sample exactly on Android 10. The small
++ * preserver below snapshots only the first 20 ms before Media3 applies its click-prevention ramp
++ * and restores those bytes in AudioTrack. It is deliberately enabled only when input and output
++ * PCM formats are identical and no encoder-delay trimming is needed; otherwise normal Media3
++ * behavior is retained rather than risking a shifted stream.
++ */
++@UnstableApi
++public final class BitPerfectRenderersFactory extends DefaultRenderersFactory {
++  private final OriginalPcmPreserver originalPcm = new OriginalPcmPreserver();
++
++  public BitPerfectRenderersFactory(Context context) {
++    super(context);
++  }
++
++  @Override
++  protected AudioSink buildAudioSink(
++      Context context, boolean enableFloatOutput, boolean enableAudioTrackPlaybackParams) {
++    AudioSink sink =
++        new DefaultAudioSink.Builder(context)
++            .setEnableFloatOutput(true)
++            .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
++            .setAudioTrackProvider(new RestoringAudioTrackProvider(originalPcm))
++            .build();
++    return new PreservingAudioSink(sink, originalPcm);
++  }
++
++  private static final class PreservingAudioSink extends ForwardingAudioSink {
++    private final OriginalPcmPreserver originalPcm;
++
++    PreservingAudioSink(AudioSink sink, OriginalPcmPreserver originalPcm) {
++      super(sink);
++      this.originalPcm = originalPcm;
++    }
++
++    @Override
++    public void configure(
++        Format inputFormat, int specifiedBufferSize, @Nullable int[] outputChannels)
++        throws AudioSink.ConfigurationException {
++      originalPcm.setInputFormat(inputFormat);
++      super.configure(inputFormat, specifiedBufferSize, outputChannels);
++    }
++
++    @Override
++    public boolean handleBuffer(
++        ByteBuffer buffer, long presentationTimeUs, int encodedAccessUnitCount)
++        throws AudioSink.InitializationException, AudioSink.WriteException {
++      originalPcm.offer(buffer);
++      try {
++        return super.handleBuffer(buffer, presentationTimeUs, encodedAccessUnitCount);
++      } finally {
++        originalPcm.clearOffer();
++      }
++    }
++  }
++
++  private static final class RestoringAudioTrackProvider
++      implements DefaultAudioSink.AudioTrackProvider {
++    private final OriginalPcmPreserver originalPcm;
++    private final DefaultAudioTrackProvider defaultProvider = new DefaultAudioTrackProvider();
++
++    RestoringAudioTrackProvider(OriginalPcmPreserver originalPcm) {
++      this.originalPcm = originalPcm;
++    }
++
++    @Override
++    public AudioTrack getAudioTrack(
++        AudioSink.AudioTrackConfig config,
++        androidx.media3.common.AudioAttributes attributes,
++        int audioSessionId,
++        @Nullable Context context) {
++      // Encoded offload is already bitstream-direct and needs AudioTrack.Builder's
++      // offload flag; it never goes through Media3's PCM ramp.
++      if (config.offload) {
++        return defaultProvider.getAudioTrack(config, attributes, audioSessionId, context);
++      }
++      originalPcm.beginAudioTrack(config);
++      return new RestoringAudioTrack(config, attributes, audioSessionId, originalPcm);
++    }
++  }
++
++  private static final class RestoringAudioTrack extends AudioTrack {
++    private final OriginalPcmPreserver originalPcm;
++
++    RestoringAudioTrack(
++        AudioSink.AudioTrackConfig config,
++        androidx.media3.common.AudioAttributes attributes,
++        int audioSessionId,
++        OriginalPcmPreserver originalPcm) {
++      super(
++          platformAttributes(config, attributes),
++          Util.getAudioFormat(config.sampleRate, config.channelConfig, config.encoding),
++          config.bufferSize,
++          AudioTrack.MODE_STREAM,
++          audioSessionId == C.AUDIO_SESSION_ID_UNSET
++              ? AudioManager.AUDIO_SESSION_ID_GENERATE
++              : audioSessionId);
++      this.originalPcm = originalPcm;
++    }
++
++    @Override
++    public int write(ByteBuffer audioData, int sizeInBytes, int writeMode) {
++      int start = audioData.position();
++      originalPcm.restore(audioData, start, sizeInBytes);
++      int written = super.write(audioData, sizeInBytes, writeMode);
++      originalPcm.commit(written);
++      return written;
++    }
++
++    @Override
++    public int write(ByteBuffer audioData, int sizeInBytes, int writeMode, long timestamp) {
++      int start = audioData.position();
++      originalPcm.restore(audioData, start, sizeInBytes);
++      int written = super.write(audioData, sizeInBytes, writeMode, timestamp);
++      originalPcm.commit(written);
++      return written;
++    }
++
++    private static android.media.AudioAttributes platformAttributes(
++        AudioSink.AudioTrackConfig config, androidx.media3.common.AudioAttributes attributes) {
++      if (!config.tunneling) {
++        return attributes.getAudioAttributesV21().audioAttributes;
++      }
++      return new android.media.AudioAttributes.Builder()
++          .setContentType(android.media.AudioAttributes.CONTENT_TYPE_MOVIE)
++          .setFlags(android.media.AudioAttributes.FLAG_HW_AV_SYNC)
++          .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
++          .build();
++    }
++  }
++
++  private static final class OriginalPcmPreserver {
++    private static final long MEDIA3_RAMP_DURATION_US = 20_000;
++
++    @Nullable private Format inputFormat;
++    @Nullable private ByteBuffer currentOfferBuffer;
++    private int currentOfferPosition;
++    private boolean currentOfferEligible;
++    @Nullable private ByteBuffer lastAppendedBuffer;
++    private int lastAppendedPosition = -1;
++    @Nullable private byte[] original;
++    private int originalBytes;
++    private int targetBytes;
++    private int committedBytes;
++    private boolean active;
++
++    synchronized void setInputFormat(Format inputFormat) {
++      this.inputFormat = inputFormat;
++    }
++
++    synchronized void offer(ByteBuffer buffer) {
++      currentOfferBuffer = buffer;
++      currentOfferPosition = buffer.position();
++      currentOfferEligible = false;
++      Format format = inputFormat;
++      if (format == null
++          || !MimeTypes.AUDIO_RAW.equals(format.sampleMimeType)
++          || format.encoderDelay != 0
++          || !Util.isEncodingLinearPcm(format.pcmEncoding)) {
++        return;
++      }
++      currentOfferEligible = true;
++      if (active
++          && originalBytes < targetBytes
++          && (lastAppendedBuffer != buffer || lastAppendedPosition != buffer.position())) {
++        appendUpToTarget(buffer, buffer.position());
++        lastAppendedBuffer = buffer;
++        lastAppendedPosition = buffer.position();
++      }
++    }
++
++    synchronized void clearOffer() {
++      currentOfferBuffer = null;
++      currentOfferEligible = false;
++    }
++
++    synchronized void beginAudioTrack(AudioSink.AudioTrackConfig config) {
++      Format format = inputFormat;
++      original = null;
++      originalBytes = 0;
++      committedBytes = 0;
++      active = false;
++      lastAppendedBuffer = null;
++      lastAppendedPosition = -1;
++      if (format == null
++          || !currentOfferEligible
++          || currentOfferBuffer == null
++          || format.pcmEncoding != config.encoding
++          || format.sampleRate != config.sampleRate
++          || format.channelCount != Integer.bitCount(config.channelConfig)) {
++        targetBytes = 0;
++        return;
++      }
++      int frameSize = Util.getPcmFrameSize(config.encoding, format.channelCount);
++      int frames =
++          (int) Util.durationUsToSampleCount(MEDIA3_RAMP_DURATION_US, config.sampleRate);
++      targetBytes = frames * frameSize;
++      original = new byte[targetBytes];
++      appendUpToTarget(currentOfferBuffer, currentOfferPosition);
++      active = true;
++      lastAppendedBuffer = currentOfferBuffer;
++      lastAppendedPosition = currentOfferPosition;
++    }
++
++    synchronized void restore(ByteBuffer buffer, int start, int requestedBytes) {
++      if (!active || committedBytes >= targetBytes) {
++        return;
++      }
++      byte[] source = original;
++      if (source == null) {
++        return;
++      }
++      int available =
++          Math.min(
++              requestedBytes,
++              Math.min(targetBytes - committedBytes, originalBytes - committedBytes));
++      for (int index = 0; index < available; index++) {
++        buffer.put(start + index, source[committedBytes + index]);
++      }
++    }
++
++    synchronized void commit(int writtenBytes) {
++      if (writtenBytes > 0 && active) {
++        committedBytes = Math.min(targetBytes, committedBytes + writtenBytes);
++        if (committedBytes >= targetBytes) {
++          active = false;
++          original = null;
++          originalBytes = 0;
++        }
++      }
++    }
++
++    private void appendUpToTarget(ByteBuffer source, int position) {
++      byte[] destination = original;
++      if (destination == null) {
++        return;
++      }
++      int count =
++          Math.min(Math.max(0, source.limit() - position), targetBytes - originalBytes);
++      if (count > 0) {
++        ByteBuffer duplicate = source.duplicate();
++        duplicate.position(position);
++        duplicate.limit(position + count);
++        duplicate.get(destination, originalBytes, count);
++        originalBytes += count;
++      }
++    }
++  }
++}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  expo-audio: 8862ac6418a604750f3a640dfb1613c696045ef942b0c035f96c59480e77c999
+  expo-audio: 63643b84f5154aab560c433ee3cfc241b919cbcddd78e36c5d19ac0cc3397aea
 
 importers:
 
@@ -28,7 +28,7 @@ importers:
         version: 55.0.17(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-audio:
         specifier: ~55.0.15
-        version: 55.0.15(patch_hash=8862ac6418a604750f3a640dfb1613c696045ef942b0c035f96c59480e77c999)(expo-asset@55.0.17(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
+        version: 55.0.15(patch_hash=63643b84f5154aab560c433ee3cfc241b919cbcddd78e36c5d19ac0cc3397aea)(expo-asset@55.0.17(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)
       expo-build-properties:
         specifier: ~55.0.15
         version: 55.0.15(expo@55.0.27)
@@ -7377,7 +7377,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-audio@55.0.15(patch_hash=8862ac6418a604750f3a640dfb1613c696045ef942b0c035f96c59480e77c999)(expo-asset@55.0.17(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0):
+  expo-audio@55.0.15(patch_hash=63643b84f5154aab560c433ee3cfc241b919cbcddd78e36c5d19ac0cc3397aea)(expo-asset@55.0.17(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0):
     dependencies:
       expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@55.0.11)(expo-router@55.0.16)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       expo-asset: 55.0.17(expo@55.0.27)(react-native@0.83.6(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)

--- a/src/app/settings/playback.tsx
+++ b/src/app/settings/playback.tsx
@@ -33,6 +33,8 @@ export default function PlaybackSettings() {
   const setAutoplaySimilar = useSettings((s) => s.setAutoplaySimilar);
   const crossfadeSec = useSettings((s) => s.crossfadeSec);
   const setCrossfadeSec = useSettings((s) => s.setCrossfadeSec);
+  const gapless = useSettings((s) => s.gapless);
+  const setGapless = useSettings((s) => s.setGapless);
   const preloadUpcoming = useSettings((s) => s.preloadUpcoming);
   const setPreloadUpcoming = useSettings((s) => s.setPreloadUpcoming);
   const replayGain = useSettings((s) => s.replayGain);
@@ -92,6 +94,18 @@ export default function PlaybackSettings() {
         <Text style={[settingsStyles.sectionTitle, offline && { marginTop: 0 }]}>
           {t('Sound')}
         </Text>
+        {/* Above crossfade, and saying so: the two decide the same moment, and
+            with crossfade set it's the one that runs. */}
+        <SwitchList
+          options={[
+            {
+              label: t('Gapless playback'),
+              description: t('No silence between songs: the next one is prepared while the current one plays. Crossfade, if set, takes over.'),
+              value: gapless,
+              onChange: setGapless,
+            },
+          ]}
+        />
         <SliderRow
           label={t('Crossfade')}
           description={t('Songs blend into each other when one ends.')}

--- a/src/store/player.ts
+++ b/src/store/player.ts
@@ -603,6 +603,12 @@ async function loadIndex(index: number, autoplay: boolean) {
     if (autoplay) p.play();
     applyLockScreen(p, song);
     onTrackChanged(song);
+    // `playQueue` installs the queue before this player/source exists, so the
+    // store subscription's first attempt to enqueue the following track has
+    // nothing to act on. Queue it again now that `replace()` has installed the
+    // current media item. Without this, the first album transition still falls
+    // back to didJustFinish → replace(), leaving an audible gap.
+    scheduleNextSource();
     // Warms up the "does it support timeOffset?" answer so the first seek
     // on a transcoded stream already has the answer cached. For ANY server
     // stream: the transcode may be the server's decision, and we only find

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -416,14 +416,10 @@ interface SettingsState {
   crossfadeSec: number;
   /**
    * Join one track to the next with no silence: the next one is queued in the
-   * player itself, which buffers it in advance. Crossfade, when set, takes over
-   * the change and this steps aside.
-   *
-   * OFF and with no way to turn it on while it is being fixed: its row in
-   * Settings is gone and the saved value is not read back, so an install that
-   * already had it on doesn't keep it. Everything else is left in place; when
-   * it works, the default goes back to true, the restore below comes back, and
-   * so does the row.
+   * player itself, which buffers it in advance. On by default (nobody asks for
+   * the gap), but it can be turned off, since it means fetching the next track
+   * while the current one plays. Crossfade, when set, takes over the change and
+   * this steps aside.
    */
   gapless: boolean;
   /**
@@ -740,7 +736,7 @@ const DEFAULTS = {
   showListRating: false,
   autoplaySimilar: true,
   crossfadeSec: 0,
-  gapless: false,
+  gapless: true,
   preloadUpcoming: false,
   autoOfflineSwitch: true,
   hideUnavailableOffline: false,
@@ -1311,6 +1307,9 @@ export const useSettings = create<SettingsState>((set, get) => ({
         }
         if (typeof parsed.crossfadeSec === 'number' && parsed.crossfadeSec >= 0) {
           set({ crossfadeSec: parsed.crossfadeSec });
+        }
+        if (typeof parsed.gapless === 'boolean') {
+          set({ gapless: parsed.gapless });
         }
         if (typeof parsed.preloadUpcoming === 'boolean') {
           set({ preloadUpcoming: parsed.preloadUpcoming });


### PR DESCRIPTION
## Summary

- Queue the next Media3 item immediately after the current source is installed, preventing the first album transition from falling back to `didJustFinish` → `replace()`.
- Restore the Gapless playback setting, enable it by default, and persist the user's preference. Crossfade still takes precedence when configured.
- Preserve Original-quality PCM by enabling float output for high-bit-depth audio and restoring samples modified by Media3's 20 ms startup ramp.
- Apply PCM preservation only when the input and output formats match exactly and no encoder-delay trimming is required. Other streams retain Media3's normal behavior.

## Why

I have tried many clients, and this is by far my favorite. There was just one issue, the gapless playback had gaps. 

The next source could be scheduled before the current player source existed. This left the first album transition unprepared and caused a small but audible pause, especially on dedicated Android audio players.

Media3 also applies a short software volume ramp whenever it creates a PCM `AudioTrack`. That changes the beginning of the decoded stream, which is incompatible with bit-perfect Original-quality playback.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint` — 0 errors; 2 pre-existing warnings in `src/app/(tabs)/index.tsx`
- `pnpm i18n:status` — Spanish has no missing translations
- Original-PCM preservation matrix: 12/12 cases passed
- Android 10 / API 29 emulator
- Android 16 / API 36 emulator
- Physical FiiO M17 running Android 10 / API 29:
  - Tested through the built-in DAC in Original quality
  - Consecutive tracks had matching sample rate and bit depth but different bitrates
  - Playback was audibly seamless across the transition
  - ADB confirmed the wired-headphone DAC route at the source's 44.1 kHz rate using float PCM
- No raw mixer underruns or application crashes were observed
