### PR TITLE
Remove lossless hires labels

### DIFF
--- a/docs/TRANSLATION-CONTEXT.md
+++ b/docs/TRANSLATION-CONTEXT.md
@@ -801,7 +801,7 @@ you are actually typing into, which is easier than reading it here.
 | `Show a star rating bar to rate the current song.` | The line under “Show rating”, explaining it |
 | `Show album & year` |  |
 | `Show devices button` |  |
-| `Show format, bitrate and Lossless / Hi-Res in the player.` | The line under “Show quality label”, explaining it |
+| `Show format and bitrate in the player.` | The line under “Show quality label”, explaining it |
 | `Show lyrics card` |  |
 | `Show lyrics on the cover` | One of the values of “On cover tap” |
 | `Show previous tracks` | Whether the queue keeps the songs already played, dimmed, above the current one |

--- a/src/app/settings/player.tsx
+++ b/src/app/settings/player.tsx
@@ -122,7 +122,7 @@ export default function PlayerSettings() {
             },
             {
               label: t('Show quality label'),
-              description: t('Show format, bitrate and Lossless / Hi-Res in the player.'),
+              description: t('Show format and bitrate in the player.'),
               value: showAudioQuality,
               onChange: setShowAudioQuality,
             },

--- a/src/components/AudioQualityBadge.tsx
+++ b/src/components/AudioQualityBadge.tsx
@@ -1,4 +1,4 @@
-/** Discreet label with format, bitrate, and whether it's lossless/Hi-Res. */
+/** Discreet label with format and bitrate */
 import { StyleSheet, Text } from 'react-native';
 
 import { type Song } from '@/api/subsonic';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -353,6 +353,7 @@
   "Show genres": "Show genres",
   "Show the album's genres as chips; tap one to browse it.": "Show the album's genres as chips; tap one to browse it.",
   "Show format, bitrate and Lossless / Hi-Res in the player.": "Show format, bitrate and Lossless / Hi-Res in the player.",
+  "Show format and bitrate in the player.": "Show format and bitrate in the player.",
   "Show history button": "Show history button",
   "Show less": "Show less",
   "Show lyrics card": "Show lyrics card",

--- a/src/lib/audioQuality.ts
+++ b/src/lib/audioQuality.ts
@@ -76,12 +76,6 @@ export function qualityLabel(
   }
   const parts: string[] = [fmt];
 
-  if (isHiRes(song)) {
-    parts.push(t('Hi-Res'));
-  } else if (isLossless(song.suffix)) {
-    parts.push(t('Lossless'));
-  }
-
   if (song.bitRate && song.bitRate > 0) {
     parts.push(`${song.bitRate} kbps`);
   }


### PR DESCRIPTION
Closes https://github.com/juananzzz/resonus/issues/125

English settings string has been renamed.
Underlying check functions are kept.