### PR TITLE
Fix: Prevent UPnP playback stalling on lock screen

### DIFF
--- a/modules/upnp-cast/android/build.gradle
+++ b/modules/upnp-cast/android/build.gradle
@@ -20,4 +20,5 @@ dependencies {
   // SSDP, SOAP and DIDL-Lite are implemented in this module so the session can
   // switch to a Sonos group coordinator and keep sending every later command
   // there as well.
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/GenericQueueProgression.kt
+++ b/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/GenericQueueProgression.kt
@@ -1,0 +1,46 @@
+package expo.modules.upnpcast
+
+/** Pure decisions shared by polling and unit tests. */
+internal object GenericQueueProgression {
+  fun nextIndex(size: Int, currentIndex: Int, playMode: String): Int? {
+    if (size <= 0 || currentIndex !in 0 until size) return null
+    return when (playMode.uppercase()) {
+      "REPEAT_ONE" -> currentIndex
+      "REPEAT_ALL", "SHUFFLE" -> (currentIndex + 1) % size
+      else -> (currentIndex + 1).takeIf { it < size }
+    }
+  }
+
+  fun isNaturalEnd(
+    observedPlaying: Boolean,
+    stoppedByController: Boolean,
+    lastPositionMs: Long,
+    lastDurationMs: Long,
+  ): Boolean {
+    if (!observedPlaying || stoppedByController) return false
+    val windowMs = maxOf(5_000L, lastDurationMs / 10)
+    return lastDurationMs <= 0 || lastPositionMs >= lastDurationMs - windowMs
+  }
+
+  /**
+   * Some renderers consume NextURI without a STOPPED state and omit TrackURI.
+   * In that case the observable handoff is an end-of-track position followed
+   * by a low position whose duration agrees with the staged item.
+   */
+  fun isStagedHandoff(
+    playbackState: String,
+    positionMs: Long,
+    durationMs: Long,
+    previousPositionMs: Long,
+    previousDurationMs: Long,
+    stagedDurationMs: Long,
+  ): Boolean {
+    if (!playbackState.equals("PLAYING", ignoreCase = true)) return false
+    if (positionMs !in 0..10_000L || previousPositionMs - positionMs < 3_000L) return false
+    if (previousDurationMs <= 0 || stagedDurationMs <= 0 || durationMs <= 0) return false
+    val previousWindowMs = maxOf(5_000L, previousDurationMs / 10)
+    val previousWasNearEnd = previousPositionMs >= previousDurationMs - previousWindowMs
+    val durationMatchesStaged = kotlin.math.abs(durationMs - stagedDurationMs) <= 2_000L
+    return previousWasNearEnd && durationMatchesStaged
+  }
+}

--- a/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/RendererSession.kt
+++ b/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/RendererSession.kt
@@ -8,6 +8,10 @@ class RendererSession(
   val location: String,
   initialDescription: DeviceDescription
 ) {
+  val isSonos: Boolean get() = description.isSonos
+
+  enum class NextUriResult { ACCEPTED, UNSUPPORTED, FAILED }
+
   @Volatile
   private var description: DeviceDescription = initialDescription
 
@@ -38,6 +42,7 @@ class RendererSession(
     val durationMs: Long,
     val trackNumber: Int?,
     val playMode: String?,
+    val currentUri: String?,
   )
 
   private data class TransportTarget(val controlUrl: String, val uid: String)
@@ -124,27 +129,6 @@ class RendererSession(
     return result.ok
   }
 
-  private suspend fun enqueueTrack(control: String, track: Track): Boolean {
-    val result = Soap.call(
-      control,
-      Services.AV_TRANSPORT,
-      "AddURIToQueue",
-      "<InstanceID>0</InstanceID>" +
-        "<EnqueuedURI>${Soap.escape(track.url)}</EnqueuedURI>" +
-        "<EnqueuedURIMetaData>${Soap.escape(Didl.forTrack(track))}</EnqueuedURIMetaData>" +
-        "<DesiredFirstTrackNumberEnqueued>0</DesiredFirstTrackNumberEnqueued>" +
-        "<EnqueueAsNext>0</EnqueueAsNext>"
-    )
-    if (!result.ok) return false
-    val firstTrack = Soap.argument(result.body, "FirstTrackNumberEnqueued")
-    val numTracks = Soap.argument(result.body, "NumTracksAdded")
-    Log.d(
-      Soap.TAG,
-      "AddURIToQueue accepted title=${track.title} firstTrack=$firstTrack numTracks=$numTracks"
-    )
-    return true
-  }
-
   private suspend fun replaceQueue(control: String, queueOwnerUid: String, tracks: List<Track>, currentIndex: Int, autoplay: Boolean, positionMs: Long, playMode: String?): Boolean {
     if (tracks.isEmpty()) return false
     val selectedIndex = currentIndex.coerceIn(0, tracks.lastIndex)
@@ -153,41 +137,9 @@ class RendererSession(
       return replaceQueueViaQueueService(control, queueOwnerUid, tracks, selectedIndex, autoplay, positionMs, playMode)
     }
 
-    if (!transport("RemoveAllTracksFromQueue", INSTANCE)) return false
-    for (track in tracks) {
-      val accepted = enqueueTrack(control, track)
-      if (!accepted) return false
-    }
-
-    val queueUri = "x-rincon-queue:$queueOwnerUid#0"
-    val queueMeta = Soap.escape(Didl.forQueueContainer(queueUri, tracks.size))
-    if (!Soap.call(
-        control,
-        Services.AV_TRANSPORT,
-        "SetAVTransportURI",
-        "<InstanceID>0</InstanceID>" +
-          "<CurrentURI>${Soap.escape(queueUri)}</CurrentURI>" +
-          "<CurrentURIMetaData>$queueMeta</CurrentURIMetaData>"
-      ).ok
-    ) {
-      return false
-    }
-
-    if (!playMode.isNullOrBlank()) {
-      if (!Soap.call(
-          control,
-          Services.AV_TRANSPORT,
-          "SetPlayMode",
-          "<InstanceID>0</InstanceID><NewPlayMode>${Soap.escape(playMode)}</NewPlayMode>"
-        ).ok
-      ) {
-        return false
-      }
-    }
-
-    if (!transport("Seek", "<InstanceID>0</InstanceID><Unit>TRACK_NR</Unit><Target>${selectedIndex + 1}</Target>")) {
-      return false
-    }
+    // AVTransport has no portable queue service. The module retains the list
+    // and progresses it; the renderer is given only the selected URI.
+    if (!setUri(control, tracks[selectedIndex])) return false
 
     if (positionMs > 0) {
       if (!seek(positionMs)) return false
@@ -197,6 +149,29 @@ class RendererSession(
       if (!play()) return false
     }
     return true
+  }
+
+  suspend fun setNextUri(track: Track): NextUriResult {
+    return setNextUri(track.url, Didl.forTrack(track))
+  }
+
+  suspend fun clearNextUri(): NextUriResult = setNextUri("", "")
+
+  private suspend fun setNextUri(uri: String, metadata: String): NextUriResult {
+    val control = avTransport ?: refreshControlUrl() ?: return NextUriResult.FAILED
+    val result = Soap.call(
+      control,
+      Services.AV_TRANSPORT,
+      "SetNextAVTransportURI",
+      "<InstanceID>0</InstanceID>" +
+        "<NextURI>${Soap.escape(uri)}</NextURI>" +
+        "<NextURIMetaData>${Soap.escape(metadata)}</NextURIMetaData>"
+    )
+    return when {
+      result.ok -> NextUriResult.ACCEPTED
+      result.unsupportedAction -> NextUriResult.UNSUPPORTED
+      else -> NextUriResult.FAILED
+    }
   }
 
   private suspend fun replaceQueueViaQueueService(
@@ -648,7 +623,8 @@ class RendererSession(
       positionMs = Didl.parseDuration(Soap.argument(position.body, "RelTime")),
       durationMs = Didl.parseDuration(Soap.argument(position.body, "TrackDuration")),
       trackNumber = trackNumber,
-      playMode = Soap.argument(settings.body, "PlayMode")
+      playMode = Soap.argument(settings.body, "PlayMode"),
+      currentUri = Soap.argument(position.body, "TrackURI")
     )
   }
 

--- a/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/Soap.kt
+++ b/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/Soap.kt
@@ -18,6 +18,10 @@ object Soap {
 
   data class Result(val body: String?, val fault: String?) {
     val ok: Boolean get() = body != null
+
+    /** UPnP error 401 is Invalid Action: the service does not implement it. */
+    val unsupportedAction: Boolean
+      get() = argument(fault, "errorCode") == "401"
   }
 
   suspend fun call(

--- a/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/UpnpCastModule.kt
+++ b/modules/upnp-cast/android/src/main/java/expo/modules/upnpcast/UpnpCastModule.kt
@@ -5,6 +5,7 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -38,6 +39,8 @@ class TrackInfo(
  * session and sent to JS as a "state" event.
  */
 class UpnpCastModule : Module() {
+  private enum class NextUriCapability { UNKNOWN, SUPPORTED, UNSUPPORTED }
+
   private data class QueueRequest(
     val tracks: List<Track>,
     val currentIndex: Int,
@@ -52,6 +55,23 @@ class UpnpCastModule : Module() {
 
   private val known = ConcurrentHashMap<String, RendererSession>()
   @Volatile private var session: RendererSession? = null
+
+  // Guarded by transportMutex. Sonos keeps using its renderer-side queue; this
+  // state is authoritative only for ordinary AVTransport renderers.
+  private var nativeQueue: List<Track> = emptyList()
+  private var nativeQueueIndex = -1
+  private var nativePlayMode = "NORMAL"
+  private var nativeQueueManaged = false
+  private var lastPlaybackState = ""
+  private var lastNonzeroPositionMs = 0L
+  private var lastNonzeroDurationMs = 0L
+  private var observedPlaying = false
+  private var stoppedByUs = false
+  private var transitionInProgress = false
+  private var stoppedPolls = 0
+  private var stagedNextIndex: Int? = null
+  private var stagedNextUrl: String? = null
+  private var nextUriCapability = NextUriCapability.UNKNOWN
 
   private fun parseQueueRequest(payloadJson: String): QueueRequest {
     val payload = JSONObject(payloadJson)
@@ -134,9 +154,14 @@ class UpnpCastModule : Module() {
         promise.resolve(false)
         return@AsyncFunction
       }
-      session = target
-      startPolling()
-      promise.resolve(true)
+      scope.launch {
+        transportMutex.withLock {
+          session = target
+          clearNativeQueueState()
+        }
+        startPolling()
+        promise.resolve(true)
+      }
     }
 
     AsyncFunction("join") { deviceId: String, targetDeviceId: String, promise: Promise ->
@@ -166,6 +191,9 @@ class UpnpCastModule : Module() {
       }
       scope.launch {
         val ok = transportMutex.withLock {
+          if (session !== current) return@withLock false
+          clearNativeQueueState()
+          stoppedByUs = !autoplay
           current.load(
             Track(
               url = url,
@@ -193,13 +221,30 @@ class UpnpCastModule : Module() {
         try {
           val request = parseQueueRequest(payloadJson)
           val ok = transportMutex.withLock {
-            current.loadQueue(
+            if (session !== current) return@withLock false
+            if (!current.isSonos) {
+              installNativeQueue(request.tracks, request.currentIndex, request.playMode)
+              stoppedByUs = !request.autoplay
+              transitionInProgress = true
+            }
+            val loaded = current.loadQueue(
               tracks = request.tracks,
               currentIndex = request.currentIndex,
               autoplay = request.autoplay,
               positionMs = request.positionMs,
               playMode = request.playMode
             )
+            if (!current.isSonos) {
+              transitionInProgress = false
+              if (loaded) {
+                resetTrackObservation(request.positionMs)
+                Log.d(Soap.TAG, "Native queue loaded count=${nativeQueue.size} currentIndex=$nativeQueueIndex title=${trackLabel(nativeQueueIndex)}")
+                stageNextLocked(current)
+              } else {
+                Log.w(Soap.TAG, "Native queue load failed currentIndex=$nativeQueueIndex")
+              }
+            }
+            loaded
           }
           promise.resolve(ok)
         } catch (e: Exception) {
@@ -218,12 +263,17 @@ class UpnpCastModule : Module() {
         try {
           val request = parseQueueRequest(payloadJson)
           val ok = transportMutex.withLock {
-            current.syncQueue(
-              tracks = request.tracks,
-              currentIndex = request.currentIndex,
-              positionMs = request.positionMs,
-              playMode = request.playMode
-            )
+            if (session !== current) return@withLock false
+            if (current.isSonos) {
+              current.syncQueue(
+                tracks = request.tracks,
+                currentIndex = request.currentIndex,
+                positionMs = request.positionMs,
+                playMode = request.playMode
+              )
+            } else {
+              syncNativeQueueLocked(current, request)
+            }
           }
           promise.resolve(ok)
         } catch (e: Exception) {
@@ -233,15 +283,22 @@ class UpnpCastModule : Module() {
     }
 
     AsyncFunction("play") { promise: Promise ->
-      scope.launch { promise.resolve(session?.play() ?: false) }
+      scope.launch { promise.resolve(transportMutex.withLock {
+        stoppedByUs = false
+        session?.play() ?: false
+      }) }
     }
 
     AsyncFunction("pause") { promise: Promise ->
-      scope.launch { promise.resolve(session?.pause() ?: false) }
+      scope.launch { promise.resolve(transportMutex.withLock {
+        stoppedByUs = true
+        observedPlaying = false
+        session?.pause() ?: false
+      }) }
     }
 
     AsyncFunction("seek") { positionMs: Double, promise: Promise ->
-      scope.launch { promise.resolve(session?.seek(positionMs.toLong()) ?: false) }
+      scope.launch { promise.resolve(transportMutex.withLock { session?.seek(positionMs.toLong()) ?: false }) }
     }
 
     AsyncFunction("setVolume") { volume: Int, promise: Promise ->
@@ -249,7 +306,15 @@ class UpnpCastModule : Module() {
     }
 
     AsyncFunction("setPlayMode") { playMode: String, promise: Promise ->
-      scope.launch { promise.resolve(session?.setPlayMode(playMode) ?: false) }
+      scope.launch { promise.resolve(transportMutex.withLock {
+        nativePlayMode = playMode
+        stagedNextIndex = null
+        stagedNextUrl = null
+        val current = session ?: return@withLock false
+        val accepted = if (current.isSonos) current.setPlayMode(playMode) else true
+        if (!current.isSonos) stageNextLocked(current, clearIfNone = true)
+        accepted
+      }) }
     }
 
     AsyncFunction("setSleepTimer") { durationSec: Double, promise: Promise ->
@@ -263,7 +328,12 @@ class UpnpCastModule : Module() {
       pollJob = null
       session = null
       scope.launch {
-        current?.stop()
+        transportMutex.withLock {
+          stoppedByUs = true
+          observedPlaying = false
+          clearNativeQueueState()
+          current?.stop()
+        }
         promise.resolve(true)
       }
     }
@@ -273,7 +343,13 @@ class UpnpCastModule : Module() {
     pollJob?.cancel()
     pollJob = scope.launch {
       while (isActive) {
-        val state = session?.state()
+        val current = session
+        val state = if (current == null) null else transportMutex.withLock {
+          if (session !== current) return@withLock null
+          val polled = current.state()
+          if (polled != null && !current.isSonos) handleGenericStateLocked(current, polled)
+          polled
+        }
         if (state != null) {
           val currentTrackNumber = state.trackNumber
           val playMode = state.playMode
@@ -293,6 +369,8 @@ class UpnpCastModule : Module() {
               "durationMs" to state.durationMs.toDouble(),
               "trackNumber" to (currentTrackNumber?.toDouble() ?: 0.0),
               "playMode" to (playMode ?: ""),
+              "nativeQueueManaged" to (nativeQueueManaged && current?.isSonos == false),
+              "queueIndex" to if (nativeQueueManaged && current?.isSonos == false) nativeQueueIndex.toDouble() else -1.0,
             ),
           )
         }
@@ -300,4 +378,212 @@ class UpnpCastModule : Module() {
       }
     }
   }
+
+  private fun installNativeQueue(tracks: List<Track>, requestedIndex: Int, playMode: String) {
+    nativeQueue = tracks
+    nativeQueueIndex = if (tracks.isEmpty()) -1 else requestedIndex.coerceIn(0, tracks.lastIndex)
+    nativePlayMode = playMode
+    nativeQueueManaged = tracks.isNotEmpty()
+    stagedNextIndex = null
+    stagedNextUrl = null
+    stoppedPolls = 0
+  }
+
+  private fun clearNativeQueueState() {
+    nativeQueue = emptyList()
+    nativeQueueIndex = -1
+    nativePlayMode = "NORMAL"
+    nativeQueueManaged = false
+    lastPlaybackState = ""
+    lastNonzeroPositionMs = 0
+    lastNonzeroDurationMs = 0
+    observedPlaying = false
+    stoppedByUs = false
+    transitionInProgress = false
+    stoppedPolls = 0
+    stagedNextIndex = null
+    stagedNextUrl = null
+    nextUriCapability = NextUriCapability.UNKNOWN
+  }
+
+  private fun resetTrackObservation(positionMs: Long = 0) {
+    lastPlaybackState = ""
+    lastNonzeroPositionMs = positionMs.coerceAtLeast(0)
+    lastNonzeroDurationMs = 0
+    observedPlaying = false
+    stoppedPolls = 0
+  }
+
+  private fun nextQueueIndex(): Int? {
+    if (!nativeQueueManaged) return null
+    return GenericQueueProgression.nextIndex(nativeQueue.size, nativeQueueIndex, nativePlayMode)
+  }
+
+  private suspend fun stageNextLocked(current: RendererSession, clearIfNone: Boolean = false) {
+    if (!nativeQueueManaged || nextUriCapability == NextUriCapability.UNSUPPORTED || transitionInProgress) return
+    val nextIndex = nextQueueIndex()
+    if (nextIndex == null) {
+      if (clearIfNone && nextUriCapability == NextUriCapability.SUPPORTED) {
+        when (current.clearNextUri()) {
+          RendererSession.NextUriResult.ACCEPTED -> Log.d(Soap.TAG, "Cleared staged next URI at end of queue")
+          RendererSession.NextUriResult.UNSUPPORTED -> nextUriCapability = NextUriCapability.UNSUPPORTED
+          RendererSession.NextUriResult.FAILED -> Log.w(Soap.TAG, "Transient failure clearing staged next URI")
+        }
+      }
+      return
+    }
+    val track = nativeQueue.getOrNull(nextIndex) ?: return
+    if (stagedNextIndex == nextIndex && stagedNextUrl == track.url) return
+    Log.d(Soap.TAG, "SetNextAVTransportURI attempt index=$nextIndex title=${track.title}")
+    when (current.setNextUri(track)) {
+      RendererSession.NextUriResult.ACCEPTED -> {
+        nextUriCapability = NextUriCapability.SUPPORTED
+        stagedNextIndex = nextIndex
+        stagedNextUrl = track.url
+        Log.d(Soap.TAG, "SetNextAVTransportURI accepted; next URI staged index=$nextIndex title=${track.title}")
+      }
+      RendererSession.NextUriResult.UNSUPPORTED -> {
+        nextUriCapability = NextUriCapability.UNSUPPORTED
+        stagedNextIndex = null
+        stagedNextUrl = null
+        Log.d(Soap.TAG, "SetNextAVTransportURI marked unsupported; native STOPPED fallback enabled")
+      }
+      RendererSession.NextUriResult.FAILED ->
+        Log.w(Soap.TAG, "SetNextAVTransportURI transient failure index=$nextIndex; playback unchanged")
+    }
+  }
+
+  private suspend fun syncNativeQueueLocked(current: RendererSession, request: QueueRequest): Boolean {
+    if (request.tracks.isEmpty()) return false
+    val oldCurrentUrl = nativeQueue.getOrNull(nativeQueueIndex)?.url
+    nativeQueue = request.tracks
+    nativeQueueIndex = oldCurrentUrl?.let { url -> request.tracks.indexOfFirst { it.url == url }.takeIf { it >= 0 } }
+      ?: request.currentIndex.coerceIn(0, request.tracks.lastIndex)
+    nativePlayMode = request.playMode
+    nativeQueueManaged = true
+    stagedNextIndex = null
+    stagedNextUrl = null
+    Log.d(Soap.TAG, "Native queue updated count=${nativeQueue.size} currentIndex=$nativeQueueIndex title=${trackLabel(nativeQueueIndex)}")
+    stageNextLocked(current, clearIfNone = true)
+    return true
+  }
+
+  private suspend fun handleGenericStateLocked(current: RendererSession, state: RendererSession.State) {
+    if (!nativeQueueManaged) return
+    val playback = state.playbackState.uppercase()
+    val stagedIndex = stagedNextIndex
+    val stagedTrack = stagedIndex?.let(nativeQueue::getOrNull)
+    val uriIdentifiedHandoff = state.currentUri?.isNotBlank() == true && state.currentUri == stagedNextUrl
+    val positionIdentifiedHandoff = stagedTrack != null && GenericQueueProgression.isStagedHandoff(
+      playbackState = playback,
+      positionMs = state.positionMs,
+      durationMs = state.durationMs,
+      previousPositionMs = lastNonzeroPositionMs,
+      previousDurationMs = lastNonzeroDurationMs,
+      stagedDurationMs = stagedTrack.durationSeconds * 1_000L,
+    )
+    val stagedStarted = stagedIndex != null && stagedIndex != nativeQueueIndex && (
+      uriIdentifiedHandoff || positionIdentifiedHandoff ||
+        (lastPlaybackState == "STOPPED" && playback == "PLAYING")
+      )
+    if (stagedStarted) {
+      nativeQueueIndex = stagedIndex!!
+      stagedNextIndex = null
+      stagedNextUrl = null
+      resetTrackObservation(state.positionMs)
+      observedPlaying = playback == "PLAYING"
+      stoppedByUs = false
+      val evidence = when {
+        uriIdentifiedHandoff -> "TrackURI"
+        positionIdentifiedHandoff -> "position/duration reset"
+        else -> "STOPPED -> PLAYING"
+      }
+      Log.d(Soap.TAG, "Renderer consumed staged URI ($evidence); native current index changed to $nativeQueueIndex title=${trackLabel(nativeQueueIndex)}")
+      stageNextLocked(current)
+    }
+
+    // Repeat-one can keep the same URI and index, so TrackURI cannot identify
+    // the handoff. A position wrap after the prior lap reached its end does.
+    val repeatOneWrapped = stagedNextIndex == nativeQueueIndex &&
+      nativePlayMode.equals("REPEAT_ONE", ignoreCase = true) &&
+      playback == "PLAYING" && state.positionMs in 0..2_000L &&
+      lastNonzeroPositionMs > 3_000L &&
+      (lastNonzeroDurationMs <= 0 || lastNonzeroPositionMs >= lastNonzeroDurationMs - maxOf(5_000L, lastNonzeroDurationMs / 10))
+    if (repeatOneWrapped) {
+      stagedNextIndex = null
+      stagedNextUrl = null
+      resetTrackObservation(state.positionMs)
+      observedPlaying = true
+      Log.d(Soap.TAG, "Native repeat-one lap restarted index=$nativeQueueIndex title=${trackLabel(nativeQueueIndex)}")
+      stageNextLocked(current)
+    }
+
+    if (state.positionMs > 0) lastNonzeroPositionMs = state.positionMs
+    if (state.durationMs > 0) lastNonzeroDurationMs = state.durationMs
+    if (playback == "PLAYING") {
+      observedPlaying = true
+      stoppedByUs = false
+      stoppedPolls = 0
+    }
+
+    if (playback == "STOPPED" && lastPlaybackState != "STOPPED") {
+      val windowMs = maxOf(5_000L, lastNonzeroDurationMs / 10)
+      val nearEnd = lastNonzeroDurationMs <= 0 || lastNonzeroPositionMs >= lastNonzeroDurationMs - windowMs
+      Log.d(Soap.TAG, "PLAYING -> STOPPED check index=$nativeQueueIndex positionMs=$lastNonzeroPositionMs durationMs=$lastNonzeroDurationMs observedPlaying=$observedPlaying stoppedByUs=$stoppedByUs nearEnd=$nearEnd")
+    }
+
+    if (playback == "STOPPED") stoppedPolls++ else if (playback != "TRANSITIONING") stoppedPolls = 0
+    val naturalEnd = GenericQueueProgression.isNaturalEnd(
+      observedPlaying,
+      stoppedByUs,
+      lastNonzeroPositionMs,
+      lastNonzeroDurationMs,
+    )
+    val rendererHandoffGrace = nextUriCapability == NextUriCapability.SUPPORTED && stagedNextIndex != null && stoppedPolls < 2
+    if (playback == "STOPPED" && naturalEnd && !rendererHandoffGrace) {
+      if (transitionInProgress) {
+        Log.d(Soap.TAG, "Duplicate transition suppressed index=$nativeQueueIndex")
+      } else {
+        if (advanceNativeQueueLocked(current)) {
+          // Do not let the STOPPED snapshot which triggered our explicit load
+          // masquerade as a renderer-side STOPPED -> PLAYING handoff next poll.
+          lastPlaybackState = "TRANSITIONING"
+          return
+        }
+      }
+    }
+    lastPlaybackState = playback
+  }
+
+  private suspend fun advanceNativeQueueLocked(current: RendererSession): Boolean {
+    val nextIndex = nextQueueIndex()
+    observedPlaying = false // makes repeated STOPPED polls idempotent
+    stoppedPolls = 0
+    if (nextIndex == null) {
+      stagedNextIndex = null
+      stagedNextUrl = null
+      Log.d(Soap.TAG, "Native queue reached end at index=$nativeQueueIndex")
+      return false
+    }
+    val track = nativeQueue[nextIndex]
+    transitionInProgress = true
+    stagedNextIndex = null
+    stagedNextUrl = null
+    Log.d(Soap.TAG, "Automatic native advancement $nativeQueueIndex -> $nextIndex title=${track.title}")
+    val loaded = current.load(track)
+    val played = loaded && current.play()
+    transitionInProgress = false
+    if (!played) {
+      Log.w(Soap.TAG, "Automatic native advancement failed targetIndex=$nextIndex")
+      return false
+    }
+    nativeQueueIndex = nextIndex
+    stoppedByUs = false
+    resetTrackObservation()
+    Log.d(Soap.TAG, "Native current index changed to $nativeQueueIndex title=${track.title}")
+    stageNextLocked(current)
+    return true
+  }
+
+  private fun trackLabel(index: Int): String = nativeQueue.getOrNull(index)?.title.orEmpty()
 }

--- a/modules/upnp-cast/android/src/test/java/expo/modules/upnpcast/GenericQueueProgressionTest.kt
+++ b/modules/upnp-cast/android/src/test/java/expo/modules/upnpcast/GenericQueueProgressionTest.kt
@@ -1,0 +1,42 @@
+package expo.modules.upnpcast
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GenericQueueProgressionTest {
+  @Test fun repeatModesChooseExpectedIndex() {
+    assertEquals(1, GenericQueueProgression.nextIndex(3, 0, "NORMAL"))
+    assertNull(GenericQueueProgression.nextIndex(3, 2, "NORMAL"))
+    assertEquals(0, GenericQueueProgression.nextIndex(3, 2, "REPEAT_ALL"))
+    assertEquals(2, GenericQueueProgression.nextIndex(3, 2, "REPEAT_ONE"))
+  }
+
+  @Test fun retainedPreStopValuesRecogniseShortTrackEnds() {
+    assertTrue(GenericQueueProgression.isNaturalEnd(true, false, 5_000, 6_000))
+    assertTrue(GenericQueueProgression.isNaturalEnd(true, false, 17_000, 19_000))
+  }
+
+  @Test fun explicitOrUnobservedStopsNeverAdvance() {
+    assertFalse(GenericQueueProgression.isNaturalEnd(true, true, 19_000, 19_000))
+    assertFalse(GenericQueueProgression.isNaturalEnd(false, false, 19_000, 19_000))
+    assertFalse(GenericQueueProgression.isNaturalEnd(true, false, 2_000, 60_000))
+  }
+
+  @Test fun unknownDurationMatchesExistingFallbackIntent() {
+    assertTrue(GenericQueueProgression.isNaturalEnd(true, false, 1_000, 0))
+  }
+
+  @Test fun seamlessRendererHandoffIsRecognisedWithoutStoppedOrTrackUri() {
+    assertTrue(GenericQueueProgression.isStagedHandoff("PLAYING", 0, 16_000, 26_000, 28_000, 16_000))
+    assertTrue(GenericQueueProgression.isStagedHandoff("PLAYING", 3_000, 70_000, 14_000, 16_000, 70_000))
+  }
+
+  @Test fun ordinaryProgressOrAnUnrelatedDurationIsNotAHandoff() {
+    assertFalse(GenericQueueProgression.isStagedHandoff("PLAYING", 15_000, 28_000, 14_000, 28_000, 16_000))
+    assertFalse(GenericQueueProgression.isStagedHandoff("PLAYING", 0, 41_000, 26_000, 28_000, 16_000))
+    assertFalse(GenericQueueProgression.isStagedHandoff("PAUSED", 0, 16_000, 26_000, 28_000, 16_000))
+  }
+}

--- a/src/store/upnp.ts
+++ b/src/store/upnp.ts
@@ -1,10 +1,10 @@
 /**
  * Integration with UPnP/DLNA renderers (native module modules/upnp-cast).
  *
- * The queue lives in the player store and here only the session is managed
- * (chosen device) and the return events. The native module polls the renderer
- * state every second; track end is inferred from a STOPPED near the end
- * (UPnP doesn't distinguish "finished" from "stopped by user").
+ * The player store remains the UI/source-of-truth queue. While connected to an
+ * ordinary renderer, a native copy owns transport progression so Android can
+ * continue between tracks while JS is suspended. Sonos keeps using its native
+ * renderer-side queue.
  */
 import { requireOptionalNativeModule } from 'expo-modules-core';
 import { create } from 'zustand';
@@ -63,6 +63,9 @@ interface NativeState {
   durationMs: number;
   trackNumber?: number;
   playMode?: string;
+  nativeQueueManaged?: boolean;
+  /** Authoritative zero-based index for a native-managed ordinary renderer. */
+  queueIndex?: number;
 }
 
 const native = requireOptionalNativeModule('UpnpCast');
@@ -82,6 +85,7 @@ let wasPlaying = false;
 /** We requested the pause ourselves: a STOPPED after this is not a track end. */
 let pausedByUs = false;
 let lastNativeTrackNumber = 0;
+let lastNativeQueueIndex = -1;
 let lastRemoteRepeat: 'off' | 'all' | 'one' | null = null;
 
 interface CachedDevice {
@@ -127,9 +131,16 @@ function onNativeState(e: NativeState) {
   const pos = (e.positionMs ?? 0) / 1000;
   const dur = (e.durationMs ?? 0) / 1000;
   const trackNumber = Math.floor(e.trackNumber ?? 0);
+  const nativeQueueIndex = Math.floor(e.queueIndex ?? -1);
   if (pos > 0) lastPositionSec = pos;
   if (dur > 0) lastDurationSec = dur;
-  if (trackNumber > 0) {
+  if (e.nativeQueueManaged && nativeQueueIndex >= 0) {
+    const changed = nativeQueueIndex !== lastNativeQueueIndex;
+    lastNativeQueueIndex = nativeQueueIndex;
+    if (changed && !loading) {
+      events?.onTrackChanged(nativeQueueIndex, pos, dur || lastDurationSec);
+    }
+  } else if (trackNumber > 0) {
     const changed = trackNumber !== lastNativeTrackNumber;
     lastNativeTrackNumber = trackNumber;
     if (changed && !loading) {
@@ -162,7 +173,7 @@ function onNativeState(e: NativeState) {
       // seconds, so a fixed 3 s threshold was too tight and the queue wouldn't
       // advance. Without known duration, we trust we were playing (better to
       // advance than to get stuck).
-      if (!finishedFired && !loading && wasPlaying && !pausedByUs) {
+      if (!e.nativeQueueManaged && !finishedFired && !loading && wasPlaying && !pausedByUs) {
         const window = Math.max(5, lastDurationSec * 0.1);
         const nearEnd = lastDurationSec <= 0 || lastPositionSec >= lastDurationSec - window;
         if (nearEnd) {
@@ -251,6 +262,7 @@ export async function upnpConnect(device: UpnpDevice): Promise<boolean> {
   lastPositionSec = 0;
   lastDurationSec = 0;
   lastNativeTrackNumber = 0;
+  lastNativeQueueIndex = -1;
   lastRemoteRepeat = null;
   finishedFired = false;
   wasPlaying = false;
@@ -275,6 +287,7 @@ export async function upnpDisconnect(silent = false): Promise<void> {
   void stopLocalHttp();
   useUpnp.setState({ connected: false, deviceId: null });
   lastNativeTrackNumber = 0;
+  lastNativeQueueIndex = -1;
   lastRemoteRepeat = null;
   lastPositionSec = 0;
   lastDurationSec = 0;
@@ -413,13 +426,6 @@ function buildUpnpQueuePayload(queue: Song[]) {
   return tracks as (ReturnType<typeof buildUpnpTrackInfo> & { url: string; mime: string })[];
 }
 
-function buildUpnpTrackPayload(song: Song) {
-  const url = buildUpnpTrackUrl(song);
-  if (!url) return null;
-  const info = buildUpnpTrackInfo(song);
-  return { url, mime: castMime(song, transcodedTo(song)), ...info };
-}
-
 /**
  * What the file will have been turned into by the time it arrives, which is
  * only ever something the SERVER does on the way out.
@@ -517,18 +523,13 @@ export async function upnpLoad(
   lastPositionSec = startTimeSec;
   lastDurationSec = current.duration ?? 0;
   try {
-    // What has to be reachable before the URLs are built. Sonos is handed the
-    // whole queue at once, so that is the whole queue. Everything else gets one
-    // track — and its neighbours, which cost nothing and cover the moment
-    // between two tracks, when the notification is still fetching the cover of
-    // the one being left (see `publishLocalFiles`: publishing replaces).
+    // Both renderer-side Sonos queues and native-managed ordinary queues need
+    // every phone-served URL to remain reachable after JS is suspended.
     const sonos = currentUpnpDevice()?.isSonos;
-    await ensureLocalFilesServed(
-      sonos ? queue : queue.slice(Math.max(0, index - 1), index + 2),
-    );
+    await ensureLocalFilesServed(queue);
     const ok = sonos
       ? await loadSonosQueue(queue, index, autoplay, startTimeSec, playMode)
-      : await loadGenericUpnpTrack(current, autoplay, startTimeSec);
+      : await loadGenericUpnpQueue(queue, index, autoplay, startTimeSec, playMode);
     if (ok && startTimeSec > 0) void native.seek(startTimeSec * 1000);
     // Not every renderer starts on its own after being handed a URI: Sonos
     // waits for an explicit Play and otherwise sits silent while the app
@@ -553,7 +554,7 @@ export async function upnpSyncQueue(
   playMode: string,
 ): Promise<boolean> {
   if (!native || !isUpnpConnected()) return false;
-  if (!currentUpnpDevice()?.isSonos) return false;
+  await ensureLocalFilesServed(queue);
   const payload = buildUpnpQueuePayload(queue);
   if (!payload) return false;
   try {
@@ -572,7 +573,6 @@ export async function upnpSyncQueue(
 
 export async function upnpSetPlayMode(playMode: string): Promise<boolean> {
   if (!native || !isUpnpConnected()) return false;
-  if (!currentUpnpDevice()?.isSonos) return true;
   try {
     return (await native.setPlayMode(playMode)) as boolean;
   } catch {
@@ -615,22 +615,33 @@ async function loadSonosQueue(
  *  lossless track has no bitrate to inherit, and 320 is as good as MP3 gets. */
 const CAST_MP3_BITRATE = 320;
 
-async function loadGenericUpnpTrack(song: Song, autoplay: boolean, startTimeSec: number): Promise<boolean> {
-  const payload = buildUpnpTrackPayload(song);
+async function loadGenericUpnpQueue(
+  queue: Song[],
+  index: number,
+  autoplay: boolean,
+  startTimeSec: number,
+  playMode: string,
+): Promise<boolean> {
+  const payload = buildUpnpQueuePayload(queue);
   if (!payload) return false;
-  let ok = (await native.load(payload.url, payload, autoplay)) as boolean;
-  // A renderer that won't take the format says so, and the answer to that is
-  // to ask the server for the one nothing refuses. Only after being turned
-  // down: the ones that do take FLAC keep getting it. Sonos never comes
-  // through here, so this is the same second chance the TVs and speakers had
-  // before the queue path existed (#70).
+  const load = (tracks: typeof payload) => native.loadQueue(JSON.stringify({
+    tracks,
+    currentIndex: index,
+    autoplay,
+    positionMs: startTimeSec * 1000,
+    playMode,
+  })) as Promise<boolean>;
+  let ok = await load(payload);
+  // Preserve the existing format fallback without throwing away the native
+  // queue: replace only the selected URI and submit the complete queue again.
   if (!ok) {
-    const mp3Url = mp3StreamUrl(song);
-    if (mp3Url && mp3Url !== payload.url) {
-      ok = (await native.load(mp3Url, { ...payload, url: mp3Url, mime: 'audio/mpeg' }, autoplay)) as boolean;
+    const mp3Url = mp3StreamUrl(queue[index]);
+    if (mp3Url && mp3Url !== payload[index]?.url) {
+      const fallback = [...payload];
+      fallback[index] = { ...fallback[index], url: mp3Url, mime: 'audio/mpeg' };
+      ok = await load(fallback);
     }
   }
-  if (ok && startTimeSec > 0) void native.seek(startTimeSec * 1000);
   return ok;
 }
 


### PR DESCRIPTION
# Fix: Prevent UPnP playback stalling on lock screen

First, huge thanks to the developers. I have tried a number of Android Navidrome clients, and this is absolutely the best that I've found.

## Summary

This PR fixes a bug where UPnP casting randomly stops after 1-3 tracks when the device screen is locked. 

It can also produce smoother track transitions for many users, including while the screen is on.

The existing Sonos-specific queue implementation remains unchanged.

## The Problem and Cause

On my setup (Pixel 7 casting to a Raspberry Pi via upmpdcli), playback would frequently stall at the end of a track unless the screen remained on. Unlocking the phone and manually skipping to the next track would immediately resume playback.

The Pi's logs showed that the renderer was behaving normally and that the native Android polling loop continued calling `GetTransportInfo`, `GetPositionInfo`, and `GetTransportSettings` while the screen was locked. Kotlin also reported the renderer’s `STOPPED` state to the app's React Native layer as expected. 

Cause: despite selecting the "unrestricted" option in the phone's battery settings, it appears Android still throttles the app's JS runtime quite heavily while the app is backgrounded or the screen is locked. Consequently, Kotlin was continuing to observe the renderer while no JavaScript ran to load and play the next track.

## Solutions

### 1. Native queue progression for ordinary UPnP renderers

The full ordinary-UPnP queue and current index are now retained in Kotlin. For these sessions, Kotlin owns end-of-track progression, while JavaScript remains responsible for queue editing and UI state.

Queue changes are synchronised to the native queue. Kotlin reports its authoritative current index back to JavaScript so the UI can reconcile when the runtime resumes.

This explicit ownership also prevents delayed JavaScript events from advancing the queue a second time.

E.g.:

```
if (!e.nativeQueueManaged && !finishedFired && !loading && wasPlaying && !pausedByUs) {
        const window = Math.max(5, lastDurationSec * 0.1);
        const nearEnd = lastDurationSec <= 0 || lastPositionSec >= lastDurationSec - window;
        if (nearEnd) {
          finishedFired = true;
          wasPlaying = false;
          events?.onFinished();
        }
      }

```
### 2. SetNextAVTransportURI support

When supported, Kotlin now stages the next track in advance using the standard `SetNextAVTransportURI` action. This provides the next track's details to the renderer in advance, allowing the UPnP device to handle track transitions. 

This allows the renderer to perform transitions at the moment a track ends without waiting for JavaScript or the next polling interval. The resulting smoothness depends on the renderer and media formats, but it is noticeably smoother on my upmpdcli setup, particularly with live albums with continuous crowd noise between tracks.

Capability is remembered per renderer session:

```
  enum class NextUriCapability {
    UNKNOWN,
    SUPPORTED,
    UNSUPPORTED
  }
```

A definite UPnP `Invalid Action` response marks the action unsupported, preventing repeated unsupported requests. Transient network failures do not disable playback or permanently mark the renderer unsupported.

For renderers without `SetNextAVTransportURI`, Kotlin retains the last nonzero position and duration and detects a genuine near-end `PLAYING` → `STOPPED` transition. It then performs: `SetAVTransportURI(next track)` followed by `Play`

## Testing

Playback is completely smooth and seamless for me now. The app can now successfully queue track after track, advancing through whole albums with the screen locked or unlocked.

The existing Sonos queue path remains separate and unchanged.